### PR TITLE
Minor fixes and questions for the oilcane biorefinery

### DIFF
--- a/biorefineries/oilcane/__init__.py
+++ b/biorefineries/oilcane/__init__.py
@@ -621,10 +621,9 @@ def load(name, cache=cache, reduce_chemicals=True,
     set_GWPCF(s.lime, 'lime', dilution=0.046) # Diluted with water
     set_GWPCF(s.denaturant, 'gasoline')
     set_GWPCF(s.FGD_lime, 'lime', dilution=0.451)
-    set_GWPCF(s.cellulase, 'cellulase', dilution=0.02) 
+    set_GWPCF(s.cellulase, 'cellulase', dilution=0.05) 
     set_GWPCF(s.urea, 'urea')
     set_GWPCF(s.caustic, 'NaOH', 0.5)
-    set_GWPCF(s.catalyst, 'NaOH', 0.5)
     set_GWPCF(s.catalyst, 'methanol catalyst mixture')
     set_GWPCF(s.methanol, 'methanol')
     set_GWPCF(s.HCl, 'HCl')

--- a/biorefineries/oilcane/__init__.py
+++ b/biorefineries/oilcane/__init__.py
@@ -998,22 +998,8 @@ def load(name, cache=cache, reduce_chemicals=True,
     
     @metric(units='%')
     def heat_exchanger_network_error():
-        return HXN.energy_balance_percent_error if HXN else 0.    
+        return HXN.energy_balance_percent_error if HXN else 0.
 
-    def GWP_displacement(): # Cradle to gate
-        GWP_total = sys.get_total_feeds_impact(GWP) + min(electricity(), 0) * GWP_characterization_factors['Electricity'] # kg CO2 eq. / yr
-        sales = (
-            biodiesel_flow() * mean_biodiesel_price
-            + ethanol_flow() * get_GWP_mean_ethanol_price()
-            + crude_glycerol_flow() * mean_glycerol_price
-        )
-        GWP_per_USD = GWP_total / sales
-        return {
-            'Ethanol': GWP_per_USD * get_GWP_mean_ethanol_price(),
-            'Biodiesel': GWP_per_USD * mean_biodiesel_price,
-            'Crude glycerol': GWP_per_USD * mean_glycerol_price,
-        }
-    dct['GWP_displacement'] = GWP_displacement
 
     @metric(name='GWP', element='Economic allocation', units='kg*CO2*eq / USD')
     def GWP_economic(): # Cradle to gate

--- a/biorefineries/oilcane/_lca_characterization_factors.py
+++ b/biorefineries/oilcane/_lca_characterization_factors.py
@@ -42,7 +42,7 @@ GWP_characterization_factors = { # Material GWP cradle-to-gate [kg*CO2*eq / kg]
 }
 
 GWP_characterization_factors['methanol catalyst mixture'] = (
-    GWP_characterization_factors['methanol'] * 0.75 + GWP_characterization_factors['NaOH'] * 0.25
+    GWP_characterization_factors['methanol'] * 0.75 + GWP_characterization_factors['NaOCH3'] * 0.25
 )
 
 def set_GWPCF(stream, name, dilution=1.):


### PR DESCRIPTION
Hi @yoelcortes , some minor fixes/questions I have on the oilcane biorefinery:

For the changes I made in this PR
1. `set_GWPCF(s.cellulase, 'cellulase', dilution=0.05)`:
```python
>>> from biorefineries import oilcane as oc
>>> oc.load('S2')
>>> oc.cellulase.show('cwt')

Stream: cellulase to <EnzymeHydrolysateMixer: M401>
 phase: 'l', T: 298.15 K, P: 101325 Pa
 composition (%): Water      95
                  Cellulase  5
                  ---------  6.62e+03 kg/hr
```
2. removal `set_GWPCF(s.catalyst, 'NaOH', 0.5)`: I believe this is just one extra line
3. `GWP_characterization_factors['methanol catalyst mixture'] = (
    GWP_characterization_factors['methanol'] * 0.75 + GWP_characterization_factors['NaOCH3'] * 0.25
)`
```python
>>> oc.load('O2')
>>> oc.catalyst.show('cwt')
Stream: catalyst to <StorageTank: T1105>
 phase: 'l', T: 298.15 K, P: 101325 Pa
 composition (%): Methanol  75
                  NaOCH3    25
                  --------  1 kg/hr
```

Additionally, there are some questions:
1. The [`GWP_displacement`](https://github.com/BioSTEAMDevelopmentGroup/Bioindustrial-Park/blob/fdeeca2a81900ecf9ab8757268f4cdd9604804d5/biorefineries/oilcane/__init__.py#L1004) function is confusing to me - it looks like economic allocation
2. For fossil-based chemicals like `denaturant`, is the CO2 emission from its eventual breakdown considered?
3. The displacement GWP is very negative for the `O1` configuration:
```python
>>> oc.load('O1')
>>> df = oc.model.metrics_at_baseline()
>>> df[('Displacement allocation', 'Ethanol GWP [kg*CO2*eq / L]')]
-3.7965138579542024
```
And I think it decreased a significantly from the old results I got before the changes you made (not sure if it's in #39, but I used to have ~-4kg CO2/**gal**), do you know why this might have happened...?

Thank you!